### PR TITLE
Add prototype FastAPI backend and core logic

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,96 @@
+"""FastAPI wrapper for Illini Prompt Nurse prototype."""
+from __future__ import annotations
+
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+import os
+from typing import Dict
+
+from core import (
+    is_message_relevant,
+    contains_crisis_language,
+    recognize_appointment_intent,
+    triage_priority,
+    disclaimer_for,
+    sanitize_message,
+    make_cache_key,
+)
+
+app = FastAPI(title="Illini Prompt Nurse")
+
+# Simple in-memory cache and storage
+CACHE: Dict[str, Dict[str, str]] = {}
+UPLOAD_DIR = os.path.join(os.path.dirname(__file__), "uploads")
+os.makedirs(UPLOAD_DIR, exist_ok=True)
+
+
+class MessageRequest(BaseModel):
+    student_id: str
+    message: str
+
+
+@app.post("/message")
+async def handle_message(req: MessageRequest):
+    """Main endpoint for student messages."""
+    if not is_message_relevant(req.message):
+        return JSONResponse(
+            {"response": "⚠️ This is not an appropriate question for Illini Prompt Nurse."},
+            status_code=400,
+        )
+
+    if contains_crisis_language(req.message):
+        # In real system, trigger escalation workflow.
+        return JSONResponse(
+            {
+                "response": "Your message has been forwarded to the Mental Health Office for urgent review.",
+                "priority": "high",
+            },
+            status_code=202,
+        )
+
+    key = make_cache_key(req.student_id, req.message)
+    if key in CACHE:
+        return {"response": CACHE[key]["response"], "cached": True}
+
+    cleaned = sanitize_message(req.message)
+    response_text = generate_stub_response(cleaned)
+
+    if disclaimer := disclaimer_for(cleaned):
+        response_text = f"{disclaimer} {response_text}"
+
+    CACHE[key] = {"response": response_text}
+
+    data = {
+        "response": response_text,
+        "priority": triage_priority(cleaned),
+        "appointment_intent": recognize_appointment_intent(cleaned),
+        "cached": False,
+    }
+    return data
+
+
+@app.post("/upload")
+async def upload_file(file: UploadFile = File(...)):
+    """Accept and store uploaded documents."""
+    contents = await file.read()
+    file_path = os.path.join(UPLOAD_DIR, file.filename)
+    with open(file_path, "wb") as f:
+        f.write(contents)
+    # Metadata extraction would happen here.
+    return {"filename": file.filename, "size": len(contents)}
+
+
+def generate_stub_response(message: str) -> str:
+    """Placeholder for GPT call; returns deterministic stub."""
+    # In production this would call OpenAI's API.
+    if "chest pain" in message.lower():
+        return "However, based on the symptoms you’ve described, you might consider visiting in person if symptoms worsen or persist."
+    return "Thanks for your message. A nurse will review your information soon."
+
+
+@app.get("/")
+async def root():
+    return {"message": "Illini Prompt Nurse API"}
+

--- a/core.py
+++ b/core.py
@@ -1,0 +1,71 @@
+"""Core logic for Illini Prompt Nurse prototype.
+
+This module implements basic message filtering, crisis detection,
+appointment recognition, and triage scoring. Functions are kept
+simple and stateless so they can be unit tested.
+"""
+from __future__ import annotations
+
+from typing import Tuple
+import re
+
+# Keywords for simple heuristics
+IRRELEVANT_PATTERNS = [
+    re.compile(r"\b(?:cow|cows|moo)\b", re.IGNORECASE),
+]
+
+CRISIS_PATTERNS = [
+    re.compile(r"\b(?:suicide|kill myself|don't want to live)\b", re.IGNORECASE),
+]
+
+APPOINTMENT_PATTERNS = [
+    re.compile(r"\b(?:appointment|schedule|come in)\b", re.IGNORECASE),
+]
+
+URGENT_PATTERNS = [
+    re.compile(r"\b(?:chest pain|difficulty breathing|shortness of breath)\b", re.IGNORECASE),
+]
+
+
+def is_message_relevant(message: str) -> bool:
+    """Return True if the message appears relevant to health triage."""
+    return not any(p.search(message) for p in IRRELEVANT_PATTERNS)
+
+
+def contains_crisis_language(message: str) -> bool:
+    """Detect potential mental health crisis language."""
+    return any(p.search(message) for p in CRISIS_PATTERNS)
+
+
+def recognize_appointment_intent(message: str) -> bool:
+    """Identify whether the student seems to request an appointment."""
+    return any(p.search(message) for p in APPOINTMENT_PATTERNS)
+
+
+def triage_priority(message: str) -> str:
+    """Return 'high' or 'routine' priority based on simple heuristics."""
+    return "high" if any(p.search(message) for p in URGENT_PATTERNS) else "routine"
+
+
+def disclaimer_for(message: str) -> str | None:
+    """Return the legal disclaimer if message contains urgent symptoms."""
+    if any(p.search(message) for p in URGENT_PATTERNS):
+        return (
+            "Illini Prompt Nurse is not legally allowed to give medical recommendations. "
+            "You must always contact McKinley Health Center for confirmation."
+        )
+    return None
+
+
+def sanitize_message(message: str, max_chars: int = 500) -> str:
+    """Trim very long messages to save tokens."""
+    message = message.strip()
+    if len(message) > max_chars:
+        return message[:max_chars] + "..."
+    return message
+
+
+def make_cache_key(student_id: str, message: str) -> str:
+    """Create a cache key from student ID and message."""
+    return f"{student_id}:{message.lower()}"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pydantic
+python-multipart

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,43 @@
+import pytest
+
+from core import (
+    is_message_relevant,
+    contains_crisis_language,
+    recognize_appointment_intent,
+    triage_priority,
+    disclaimer_for,
+    sanitize_message,
+    make_cache_key,
+)
+
+
+def test_irrelevant_message():
+    assert not is_message_relevant("I like cows")
+
+
+def test_crisis_detection():
+    assert contains_crisis_language("I don't want to live anymore")
+
+
+def test_appointment_intent():
+    assert recognize_appointment_intent("Can I schedule an appointment?")
+
+
+def test_triage_priority_high():
+    assert triage_priority("I have chest pain") == "high"
+
+
+def test_disclaimer_present():
+    assert disclaimer_for("chest pain") is not None
+
+
+def test_sanitize_message_trims_long_text():
+    msg = "a" * 600
+    assert sanitize_message(msg).endswith("...")
+
+
+def test_cache_key_consistency():
+    k1 = make_cache_key("123", "Hello")
+    k2 = make_cache_key("123", "hello")
+    assert k1 == k2
+


### PR DESCRIPTION
## Summary
- implement FastAPI API skeleton with message filtering, disclaimers, caching and file uploads
- add core utilities for crisis detection, appointment intent and triage priority
- include unit tests for heuristics and basic sanitization

## Testing
- `PYTHONPATH=. pytest tests/test_core.py -q`
- `pip install -q -r requirements.txt` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689ff1b206b08328a8f3dc4fcbdc3ecb