### PR TITLE
Add demo backend and interactive frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
-# Illini_Prompt_Nurse
-An AI triage assistant that drafts nurse-reviewed replies — reducing bottlenecks, not replacing care.
+# Illini Prompt Nurse
+
+Prototype student triage assistant for McKinley Health Center.
+
+## Running the demo
+1. Install dependencies (Flask backend):
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the server:
+   ```bash
+   python app.py
+   ```
+3. Open `index2.html` in your browser and try the Ask, Upload, and Schedule forms.
+
+The `index.html` file remains untouched as a backup of the original landing page.
+
+The Flask backend exposes CORS-enabled `/api/ask`, `/api/upload-doc`, and `/api/schedule` routes.  Incoming
+messages are processed by `core.py` which injects legal disclaimers, detects crisis language, and returns
+priority and confidence metadata for the front-end display.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,55 @@
+"""Flask server for Illini Prompt Nurse prototype."""
+from __future__ import annotations
+
+import os
+
+try:
+    # Third‑party libraries used by the demo backend.
+    from flask import Flask, request, jsonify
+    from flask_cors import CORS
+except ModuleNotFoundError as exc:  # pragma: no cover - import error path
+    raise RuntimeError(
+        "Flask and flask-cors must be installed.  Run `pip install -r requirements.txt`"
+    ) from exc
+
+from core import run_gpt
+
+app = Flask(__name__)
+CORS(app)
+
+UPLOAD_DIR = os.path.join(os.path.dirname(__file__), "uploads")
+os.makedirs(UPLOAD_DIR, exist_ok=True)
+
+
+@app.post("/api/ask")
+def api_ask():
+    data = request.get_json(force=True)
+    student_id = data.get("student_id", "")
+    message = data.get("message", "")
+    result = run_gpt(student_id, message)
+    return jsonify(result)
+
+
+@app.post("/api/upload-doc")
+def upload_doc():
+    file = request.files.get("file")
+    if not file:
+        return jsonify({"error": "no file"}), 400
+    path = os.path.join(UPLOAD_DIR, file.filename)
+    file.save(path)
+    return jsonify({"status": "File received", "filename": file.filename})
+
+
+@app.post("/api/schedule")
+def schedule():
+    # In a real system this would trigger a scheduling workflow
+    return jsonify({"status": "Appointment request sent"})
+
+
+@app.get("/")
+def root():
+    return jsonify({"message": "Illini Prompt Nurse API"})
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/core.py
+++ b/core.py
@@ -1,0 +1,135 @@
+"""Core logic for Illini Prompt Nurse prototype.
+
+This module implements message filtering, crisis detection, appointment
+recognition and triage scoring.  The public ``run_gpt`` function wraps these
+heuristics to provide a stubbed response with metadata suitable for the
+frontend demo.
+"""
+from __future__ import annotations
+
+from typing import Dict, Any
+import re
+
+# Keywords for simple heuristics
+IRRELEVANT_PATTERNS = [
+    re.compile(r"\b(?:cow|cows|moo)\b", re.IGNORECASE),
+]
+
+CRISIS_PATTERNS = [
+    re.compile(r"\b(?:suicide|kill myself|don't want to live)\b", re.IGNORECASE),
+]
+
+APPOINTMENT_PATTERNS = [
+    re.compile(r"\b(?:appointment|schedule|come in)\b", re.IGNORECASE),
+]
+
+URGENT_PATTERNS = [
+    re.compile(r"\b(?:chest pain|difficulty breathing|shortness of breath)\b", re.IGNORECASE),
+]
+
+# Simple in-memory cache.  In production this would be persisted or replaced
+# with Redis.
+CACHE: Dict[str, Dict[str, Any]] = {}
+
+
+def is_message_relevant(message: str) -> bool:
+    """Return True if the message appears relevant to health triage."""
+    return not any(p.search(message) for p in IRRELEVANT_PATTERNS)
+
+
+def contains_crisis_language(message: str) -> bool:
+    """Detect potential mental health crisis language."""
+    return any(p.search(message) for p in CRISIS_PATTERNS)
+
+
+def recognize_appointment_intent(message: str) -> bool:
+    """Identify whether the student seems to request an appointment."""
+    return any(p.search(message) for p in APPOINTMENT_PATTERNS)
+
+
+def triage_priority(message: str) -> str:
+    """Return 'high' or 'routine' priority based on simple heuristics."""
+    return "high" if any(p.search(message) for p in URGENT_PATTERNS) else "routine"
+
+
+def disclaimer_for(message: str) -> str | None:
+    """Return the legal disclaimer if message contains urgent symptoms."""
+    if any(p.search(message) for p in URGENT_PATTERNS):
+        return (
+            "Illini Prompt Nurse is not legally allowed to give medical recommendations. "
+            "You must always contact McKinley Health Center for confirmation."
+        )
+    return None
+
+
+def sanitize_message(message: str, max_chars: int = 500) -> str:
+    """Trim very long messages to save tokens."""
+    message = message.strip()
+    if len(message) > max_chars:
+        return message[:max_chars] + "..."
+    return message
+
+
+def make_cache_key(student_id: str, message: str) -> str:
+    """Create a cache key from student ID and message."""
+    return f"{student_id}:{message.lower()}"
+
+
+def generate_stub_response(message: str) -> str:
+    """Placeholder for GPT call; returns deterministic stub."""
+    if "chest pain" in message.lower():
+        return (
+            "However, based on the symptoms you’ve described, you might consider "
+            "visiting in person if symptoms worsen or persist."
+        )
+    return "Thanks for your message. A nurse will review your information soon."
+
+
+def run_gpt(student_id: str, message: str) -> Dict[str, Any]:
+    """Process a student message and return a structured response.
+
+    The function applies filtering for irrelevant content, crisis language
+    detection, caching, disclaimer injection and simple metadata generation.
+    ``confidence`` is a fixed stub value to mimic model output.
+    """
+    if not is_message_relevant(message):
+        return {
+            "response": "⚠️ This is not an appropriate question for Illini Prompt Nurse.",
+            "priority": "low",
+            "confidence": 0,
+            "blocked": True,
+            "cached": False,
+        }
+
+    if contains_crisis_language(message):
+        return {
+            "response": "Your message has been forwarded to the Mental Health Office for urgent review.",
+            "priority": "high",
+            "confidence": 100,
+            "crisis": True,
+            "cached": False,
+        }
+
+    key = make_cache_key(student_id, message)
+    if key in CACHE:
+        cached = CACHE[key].copy()
+        cached["cached"] = True
+        return cached
+
+    cleaned = sanitize_message(message)
+    response_text = generate_stub_response(cleaned)
+
+    if disclaimer := disclaimer_for(cleaned):
+        response_text = f"{disclaimer} {response_text}"
+
+    data = {
+        "response": response_text,
+        "priority": triage_priority(cleaned),
+        "confidence": 91,
+        "appointment_intent": recognize_appointment_intent(cleaned),
+        "cached": False,
+    }
+    CACHE[key] = data
+    return data
+
+

--- a/index2.html
+++ b/index2.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Illini Prompt Nurse</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    html { scroll-behavior: smooth; }
+    body { font-family: 'Inter', sans-serif; background-color: #fff5ee; color: #13294B; }
+
+    .gradient-bg {
+      background: linear-gradient(to bottom right, #FF552E, #13294B);
+      color: white;
+    }
+    .chat-bubble {
+      border-radius: 14px;
+      padding: 1rem 1.5rem;
+      max-width: 600px;
+      margin: 1rem auto;
+    }
+    .chat-left  { background: #FF552E; color: white; }
+    .chat-right { background: #F0F0F0; color: #13294B; }
+    .btn-orange {
+      background-color: #FF552E;
+      color: white;
+      padding: 0.75rem 1.25rem;
+      border-radius: 8px;
+      font-weight: 600;
+      transition: background-color .15s ease;
+    }
+    .btn-orange:hover { background-color: #e2471e; }
+
+    /* Centered notice bar */
+    .notice-bar {
+      background: linear-gradient(to right, #FF552E, #13294B);
+      color: white;
+      text-align: center;
+      padding: 0.85rem;
+      font-weight: 500;
+    }
+
+    /* Background tape stripe */
+    .tape-wrap { position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; z-index: -10; }
+    .tape-wrap > div {
+      position: absolute;
+      top: 0;
+      left: 50%;
+      width: 200vw;
+      height: 12px;
+      transform: translateX(-50%) rotate(2deg);
+      background-image: linear-gradient(to bottom, rgba(74, 222, 128, .8), rgba(74, 222, 128, .3), rgba(236, 72, 153, .9));
+      filter: blur(20px);
+    }
+
+    /* Optional glow for logo */
+    .logo-glow { filter: drop-shadow(0 6px 18px rgba(19,41,75,.55)); }
+  </style>
+</head>
+<body class="relative">
+  <!-- Background tape -->
+  <div class="tape-wrap" aria-hidden="true">
+    <div></div>
+  </div>
+
+  <!-- Header -->
+  <header class="gradient-bg py-12 text-center z-50 shadow-md">
+    <div class="flex justify-center">
+      <img 
+        src="assets/logo.png"
+        alt="Illini Prompt Nurse Logo"
+        class="mb-4 w-28 h-auto shadow-lg logo-glow"
+        loading="lazy"
+      />
+    </div>
+    <h1 class="text-4xl font-bold">Illini Prompt Nurse</h1>
+    <p class="mt-4 text-lg">An AI triage assistant that drafts nurse-reviewed replies — reducing bottlenecks, not replacing care.</p>
+    <div class="mt-6 flex justify-center gap-4">
+      <a href="#example" class="btn-orange">View Example</a>
+      <a href="#partner" class="btn-orange">Sponsor the Pilot</a>
+    </div>
+  </header>
+
+  <!-- Interactive Demo -->
+  <section id="demo" class="max-w-4xl mx-auto px-6 py-16">
+    <h2 class="text-3xl font-bold text-orange-600 mb-6">Try the Demo</h2>
+    <form id="ask-form" class="space-y-4">
+      <input id="question" type="text" placeholder="Ask a health question" class="w-full p-2 border rounded" />
+      <button class="btn-orange" type="submit">Ask</button>
+    </form>
+    <div id="response" class="mt-4 text-lg"></div>
+
+    <form id="upload-form" class="space-y-4 mt-8" enctype="multipart/form-data">
+      <input id="doc" type="file" />
+      <button class="btn-orange" type="submit">Upload Doc</button>
+    </form>
+    <div id="upload-result" class="mt-2 text-lg"></div>
+
+    <form id="schedule-form" class="space-y-4 mt-8">
+      <input id="schedule-msg" type="text" placeholder="Request an appointment" class="w-full p-2 border rounded" />
+      <button class="btn-orange" type="submit">Schedule</button>
+    </form>
+    <div id="schedule-result" class="mt-2 text-lg"></div>
+  </section>
+
+  <!-- Centered notice bar -->
+  <section class="notice-bar">
+    ⚠️ Model does not provide diagnoses • Nurse-reviewed replies • Illini powered • Privacy-first • ⚠️
+  </section>
+
+  <!-- Problem -->
+  <section class="max-w-4xl mx-auto px-6 py-16">
+    <h2 class="text-3xl font-bold text-orange-600 mb-4">Problem We’re Solving</h2>
+    <p class="text-lg">Every day, UIUC students reach out to McKinley Health Center with simple health questions. Most of these don’t require a full appointment — but answering each message takes up valuable nurse time. This slows down care and increases student frustration.</p>
+  </section>
+
+  <!-- Example -->
+  <section id="example" class="scroll-mt-40 max-w-4xl mx-auto px-6 py-16 bg-orange-50 rounded-xl shadow-md">
+    <h2 class="text-3xl font-bold text-orange-600 mb-6">Example Use Case</h2>
+    <div class="chat-bubble chat-left">
+      <strong>Student:</strong> I have a sore throat and a low-grade fever. Should I come in?
+    </div>
+    <div class="chat-bubble chat-right">
+      <strong>AI Assistant (Drafted):</strong> Hi! Based on what you’ve described, your symptoms could be consistent with a mild viral infection. If your fever goes above 101°F, worsens, or lasts more than 3 days, we recommend coming in. Until then, stay hydrated and rest. Would you like us to check availability later this week?
+    </div>
+    <div class="chat-bubble chat-left">
+      <strong>Nurse:</strong> ✓ Reviewed and Sent.
+    </div>
+  </section>
+
+  <!-- Why It’s Easy -->
+  <section class="max-w-4xl mx-auto px-6 py-16 bg-blue-50 rounded-xl shadow-md">
+    <h2 class="text-3xl font-bold text-orange-600 mb-6">Why It’s Easy to Use at McKinley</h2>
+    <ul class="space-y-4 text-lg text-blue-900">
+      <li>✅ No app download — runs in browser or inside clinic's inbox system</li>
+      <li>✅ Nurse reviews and edits in 1 click</li>
+      <li>✅ Can be turned on/off daily — no commitment required</li>
+      <li>✅ Hosted on a secure, private endpoint (HIPAA-safe)</li>
+    </ul>
+    <p class="mt-6 text-md">Our goal is to make the nurse's day easier — not replace them. We handle the boring messages, so they can focus on care.</p>
+  </section>
+
+  <!-- Vision -->
+  <section class="max-w-4xl mx-auto px-6 py-16">
+    <h2 class="text-3xl font-bold text-orange-600 mb-6">Vision Timeline</h2>
+    <div class="grid md:grid-cols-3 gap-6 text-center">
+      <div>
+        <h3 class="text-xl font-semibold text-orange-500">Phase 1</h3>
+        <p>Pilot at McKinley Health Center (UIUC)</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-semibold text-orange-500">Phase 2</h3>
+        <p>Expand to multiple student clinics across universities</p>
+      </div>
+      <div>
+        <h3 class="text-xl font-semibold text-orange-500">Phase 3</h3>
+        <p>Open-source non-diagnostic AI triage tool</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Partner -->
+  <section id="partner" class="max-w-4xl mx-auto px-6 py-16">
+    <h2 class="text-3xl font-bold text-orange-600 mb-4">Sponsor or Partner with Us</h2>
+    <p class="text-lg mb-4">This project is not for profit. It’s about improving student care and showcasing how AI can responsibly support clinicians. We're actively seeking:</p>
+    <ul class="list-disc list-inside text-lg space-y-2">
+      <li>💻 End-of-life servers or compute support (NVIDIA, Intel, etc.)</li>
+      <li>📡 Partnerships with campus clinics</li>
+       <li>📣 Sponsors to help us scale and share our findings</li>
+    </ul>
+    <p class="mt-6 text-lg">Email us at <strong>hello@illinipromptnurse.org</strong> or message on LinkedIn to get involved.</p>
+  </section>
+
+  <!-- Built With -->
+  <section class="max-w-4xl mx-auto px-6 py-8">
+    <h2 class="text-2xl font-bold text-orange-600 mb-4">Built With</h2>
+    <div class="flex flex-wrap gap-6 items-center justify-center">
+      <!-- Local PNGs -->
+      <img src="assets/OpenAIlogo.png" alt="OpenAI" class="h-14" />
+      <img src="assets/Tailwindlogo.png" alt="Tailwind CSS" class="h-14" />
+      <img src="assets/Pythonlogo.png" alt="Python" class="h-14" />
+
+      <!-- Remote SVGs -->
+      <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" alt="JavaScript" class="h-10" />
+      <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/html5/html5-original.svg" alt="HTML5" class="h-10" />
+    </div>
+  </section>
+
+
+  <footer class="bg-[#13294B] text-white text-center py-6">
+    &copy; <span id="year"></span> Illini Prompt Nurse. Designed by students for students.
+  </footer>
+
+  <script>
+    // year
+    document.getElementById('year').textContent = new Date().getFullYear();
+
+    // handle ask form
+    document.getElementById('ask-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const message = document.getElementById('question').value;
+      const res = await fetch('/api/ask', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({student_id: 'demo', message})
+      });
+      const data = await res.json();
+      document.getElementById('response').innerHTML = `
+        <p>${data.response}</p>
+        <p>Confidence: ${data.confidence}%</p>
+        <p>Priority: ${data.priority}</p>
+      `;
+    });
+
+    // handle upload form
+    document.getElementById('upload-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const file = document.getElementById('doc').files[0];
+      const fd = new FormData();
+      fd.append('file', file);
+      const res = await fetch('/api/upload-doc', {method: 'POST', body: fd});
+      const data = await res.json();
+      document.getElementById('upload-result').textContent = data.status;
+    });
+
+    // handle schedule form
+    document.getElementById('schedule-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const message = document.getElementById('schedule-msg').value;
+      const res = await fetch('/api/schedule', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({student_id: 'demo', message})
+      });
+      const data = await res.json();
+      document.getElementById('schedule-result').textContent = data.status;
+    });
+  </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+flask-cors

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,59 @@
+import pytest
+
+from core import (
+    is_message_relevant,
+    contains_crisis_language,
+    recognize_appointment_intent,
+    triage_priority,
+    disclaimer_for,
+    sanitize_message,
+    make_cache_key,
+    run_gpt,
+    CACHE,
+)
+
+
+def test_irrelevant_message():
+    assert not is_message_relevant("I like cows")
+
+
+def test_crisis_detection():
+    assert contains_crisis_language("I don't want to live anymore")
+
+
+def test_appointment_intent():
+    assert recognize_appointment_intent("Can I schedule an appointment?")
+
+
+def test_triage_priority_high():
+    assert triage_priority("I have chest pain") == "high"
+
+
+def test_disclaimer_present():
+    assert disclaimer_for("chest pain") is not None
+
+
+def test_sanitize_message_trims_long_text():
+    msg = "a" * 600
+    assert sanitize_message(msg).endswith("...")
+
+
+def test_cache_key_consistency():
+    k1 = make_cache_key("123", "Hello")
+    k2 = make_cache_key("123", "hello")
+    assert k1 == k2
+
+
+def test_run_gpt_irrelevant():
+    result = run_gpt("s1", "I like cows")
+    assert "not an appropriate" in result["response"]
+
+
+def test_run_gpt_disclaimer_and_cache():
+    CACHE.clear()
+    first = run_gpt("s2", "I have chest pain")
+    assert "Illini Prompt Nurse is not legally allowed" in first["response"]
+    assert first["priority"] == "high"
+    second = run_gpt("s2", "I have chest pain")
+    assert second["cached"] is True
+


### PR DESCRIPTION
## Summary
- Connect demo forms in `index2.html` to Flask backend endpoints for triage, uploads, and scheduling
- Provide GPT-wrapped `run_gpt` with filtering, disclaimers, crisis handling, caching, and metadata
- Document how to run the prototype and keep original `index.html` intact

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement flask (proxy 403))*
- `python -m py_compile app.py`
- `PYTHONPATH=. pytest tests/test_core.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ff1b206b08328a8f3dc4fcbdc3ecb