### PR TITLE
Load OpenAI API key from environment

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,9 +5,13 @@ from fastapi import FastAPI, UploadFile, File, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from dotenv import load_dotenv
 import os
 from typing import Dict
 import openai
+
+load_dotenv()
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
 from core import (
     is_message_relevant,
@@ -92,6 +96,7 @@ async def upload_file(file: UploadFile = File(...)):
 def generate_stub_response(message: str) -> tuple[str, dict]:
     """Call OpenAI's ChatCompletion API and return text plus metadata."""
     result = openai.ChatCompletion.create(
+        api_key=OPENAI_API_KEY,
         model="gpt-3.5-turbo",
         messages=[{"role": "user", "content": message}],
     )

--- a/core.py
+++ b/core.py
@@ -6,14 +6,7 @@ simple and stateless so they can be unit tested.
 """
 from __future__ import annotations
 
-from typing import Tuple
-import os
 import re
-import openai
-from dotenv import load_dotenv
-
-load_dotenv()
-openai.api_key = os.getenv("OPENAI_API_KEY")
 
 # Keywords for simple heuristics
 IRRELEVANT_PATTERNS = [


### PR DESCRIPTION
## Summary
- Load environment variables with `python-dotenv` in `app.py` and read `OPENAI_API_KEY`
- Pass API key to OpenAI chat completion calls
- Remove unused OpenAI configuration from `core.py`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'core')*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a060e7983c8328ac19fbe71920b7e9