### PR TITLE
Enable CORS middleware for FastAPI API

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from fastapi import FastAPI, UploadFile, File
 from fastapi.responses import JSONResponse
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from dotenv import load_dotenv
@@ -24,6 +25,17 @@ from core import (
 )
 
 app = FastAPI(title="Illini Prompt Nurse")
+
+# Enable CORS so the API can be accessed from a browser-based frontend.
+# This middleware handles preflight OPTIONS requests and sets the proper
+# Access-Control-* headers in responses.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # In production, restrict this to trusted origins.
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # Simple in-memory cache and storage
 CACHE: Dict[str, Dict[str, str]] = {}

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,21 @@
+from fastapi.testclient import TestClient
+from app import app
+
+
+client = TestClient(app)
+
+
+def test_cors_preflight_options():
+    response = client.options(
+        "/message",
+        headers={
+            "Origin": "http://example.com",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert response.status_code == 200
+    # When allow_credentials=True Starlette echoes back the origin rather than "*".
+    assert (
+        response.headers.get("access-control-allow-origin")
+        == "http://example.com"
+    )


### PR DESCRIPTION
## Summary
- enable CORS via FastAPI's CORSMiddleware so browsers can call the API
- add a regression test verifying OPTIONS preflight is handled

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a06ab2ef7c83289ac28c607c7c7c93